### PR TITLE
fixed broken image

### DIFF
--- a/assets/less/team.less
+++ b/assets/less/team.less
@@ -2,7 +2,7 @@
     background: rgb(245,245,245);
     background: linear-gradient(180deg, rgba(245,245,245,1) 0%, rgba(135,199,181,1) 10%);
     height: 100%;
-    margin: 0;
+    
     background-repeat: no-repeat;
     background-attachment: fixed;
     width: 70%;
@@ -10,6 +10,9 @@
     h3{
         margin-top:1%;
         font-size:2.5rem;
+    }
+    .navbar{
+        border:1px solid darkgrey;
     }
 }
 
@@ -57,27 +60,7 @@
 			width:95%;
 		}
 	}
-#teambody{
-    .container{
-    width:100%;
-    }
-    .navbar{
-        border:1px solid darkgrey;
-    }
-//     // .navbar .navbar-brand{
-//     //     font-family: 'Fugaz One', cursive;
-//     //     color: #85bb65;
-//     //     font-size: 6rem;
-//     //     width: 100%;
-//     //     text-align:center;
-        
-//     // }
-//     // .navbar .navbar-brand:hover{
-//     //     color:#000;
-//     // }
-    
 
-}
 // .navbar .navbar-brand{
 //     font-family: 'Fugaz One', cursive;
 //     color: #85bb65;

--- a/team.html
+++ b/team.html
@@ -95,7 +95,7 @@
             </div>
 
             <div class="teammember">
-                <img src="assets/img/Teampics/ramon.png">
+                <img src="assets/img/Teampics/ramon.PNG">
                 <h3>Ramon Audain</h3>
                 <p>Web UI Developer</p>
             </div>


### PR DESCRIPTION
One team pic worked locally but didn't when hosted here on github. Maybe because the case of the extension didn't agree? Couldn't find an easy way to rename the file on github and I"m still grappling with "git pull" in all honestly. Team.html now references a correctly-cased filename which should fix our broken pic.